### PR TITLE
patched issue #6

### DIFF
--- a/src/Presenter.php
+++ b/src/Presenter.php
@@ -174,6 +174,6 @@ abstract class Presenter
      */
     public function get()
     {
-        return $this->generatedData;
+        return $this->generatedData ?? [];
     }
 }


### PR DESCRIPTION
Returning an empty array to avoid fatal 500 & keep the strict return type (array) 